### PR TITLE
🔧 chore: Claude Code用Python開発環境設定を追加

### DIFF
--- a/config/claude_code/python/python_coding_style.md
+++ b/config/claude_code/python/python_coding_style.md
@@ -1,0 +1,339 @@
+# python スタイルガイド
+
+## 前提
+
+- python のバージョンは **3.12** 以上を前提としています。
+- コードの可読性と保守性を重視し、PEP8 に準拠したスタイルを採用します。
+
+## 依存関係管理
+
+依存関係の管理には`uv`を使用しています。`pip`は禁止としているため、`uv`を使用してパッケージのインストールや仮想環境の管理を行ってください。
+`uv`の使い方は @uv.md を参照してください。
+
+## format/lint
+
+### ライブラリ
+
+コードのフォーマットには`ruff`を使用しています。
+
+### 規則
+
+- フォーマットとリンティングのルールは、`ruff.toml`に記載されています。
+- `pyproject.toml`にルールを記載することもできますが、原則として`ruff.toml`に記載してください。
+- `ruff.toml`の ignore ルールは変更しないでください。実装時にエラーが発生することがありますが、エラーログに従ってコードを修正してください。
+- コード単位で format/lint を無視することも禁止です。コードの末尾に`# noqa: <rule>`を追加することは許可されていません。
+
+### 使い方
+
+ワークスペース全体に適用する場合は、以下の実行をしてください
+
+```bash
+# format
+uv run format
+
+# lint
+uv run check --fix
+```
+
+特定のファイルやディレクトリに対して実行する場合は、以下のように指定してください。
+
+```bash
+# format
+uv run format <file_or_directory>
+
+# lint
+uv run check --fix <file_or_directory>
+```
+
+## 型チェック
+
+### ライブラリ
+
+型チェックには`mypy`を使用しています。
+
+### 規則
+
+- 型チェックのルールは、`mypy.ini`に記載されています。
+- `pyproject.toml`にルールを記載することもできますが、原則として`mypy.ini`に記載してください。
+- `mypy.ini`の ignore ルールは変更しないでください。実装時にエラーが発生することがありますが、エラーログに従ってコードを修正してください。
+- コード単位で型チェックを無視することも禁止です。型チェックを無視するためのコメント（例：`# type: ignore`）を追加することは許可されていません。
+
+### 使い方
+
+ワークスペース全体に適用する場合は、以下の実行をしてください
+
+```bash
+uv run mypy ./
+```
+
+特定のファイルやディレクトリに対して実行する場合は、以下のように指定してください。
+
+```bash
+uv run mypy <file_or_directory>
+```
+
+## テスト
+
+### ライブラリ
+
+テストには`pytest`を使用しています。
+
+### 規則
+
+- テストのルールは、`pytest.ini`に記載されています。
+- `pyproject.toml`にルールを記載することもできますが、原則として`pytest.ini`に記載してください。
+
+## 型安全性とエラーハンドリング
+
+### 型アノテーション
+
+#### 基本方針
+
+- 全ての関数とメソッドに型アノテーションを記載する
+- 型アノテーションは PEP585 に従い、`typing.List` や `typing.Dict` ではなく、組み込みの `list` や `dict` を使用する
+- mypy の型チェックを必ず通すこと
+- `typing.Any`は極力使用しない。ただし、外部ライブラリや動的なデータ構造を扱う場合は例外とする
+- 型の複雑さよりも可読性を優先し、必要に応じて Type Alias や NewType を使用して可読性を向上させる、もしくは pydantic などのデータモデルを使用する
+
+#### TypeAlias vs NewType vs Pydantic の使い分け
+
+| 手法          | 用途           | 静的型チェック           | 実行時型チェック |
+| ------------- | -------------- | ------------------------ | ---------------- |
+| **TypeAlias** | 可読性向上     | ❌                       | ❌               |
+| **NewType**   | 型安全性確保   | ✅ (mypy でチェック可能) | ❌ (実体は同じ)  |
+| **Pydantic**  | バリデーション | ✅ (mypy でチェック可能) | ✅               |
+
+##### TypeAlias
+
+- 可読性を向上させるために使用しますが、型安全性は提供しません。
+- ドメインコードをコードに明示的に示したいが、型安全性は必要ない場合に使用します。
+- `typing.TypeAlias`は 3.12 から非推奨となり、`type`を使って型エイリアスであることを明示することが推奨されています。
+
+```python
+UserId: type = int
+```
+
+##### NewType
+
+- 型安全性を確保するために使用します。
+- ランタイムでは同じ型として扱われるため、型チェックツール（mypy など）でのみ効果があります。
+- ID, 単位, 為替レートなど「値は同じ型でも混ぜたら危険」な場面、ランタイム性能を落とさずに静的解析で早期にバグを見つけるために使用します。
+
+```python
+from typing import NewType
+
+UserId = NewType('UserId', int)
+
+def get_user_name(user_id: UserId) -> str:
+    ...
+
+  get_user_name(UserId(123))  # 型安全性が確保される
+  get_user_name(123)  # mypy エラー
+```
+
+##### Pydantic
+
+- データのバリデーションとシリアライゼーションを行うために使用します。
+- データモデルを定義し、実行時にデータの整合性
+- API や外部ファイルなど、信頼できないデータソースからの入力を扱う場合に使用します。
+
+```python
+from pydantic import BaseModel, Field, EmailStr
+class User(BaseModel):
+    id: int
+    name: str
+    email: EmailStr = Field(..., description="ユーザーのメールアドレス")
+
+User(id=1, name="John Doe", email="hoge@gmail.com")  # 正常
+User(id=2, name="Jane Doe", email="invalid-email")  # ValidationError
+```
+
+#### Good/Bad の例
+
+TODO: 長くなりすぎるとコンテキストを圧迫するため、必要な部分を考え中
+
+### エラーハンドリング
+
+#### 基本方針
+
+- 具体的な例外タイプをキャッチし、`Exception` の汎用キャッチは避ける
+- 例外の再発生時は context を保持する（`raise ... from e`）
+- カスタム例外クラスでドメインエラーを表現する
+
+#### 例外の適切なキャッチ
+
+```python
+# Good: 具体的な例外をキャッチ
+def read_config_file(file_path: str) -> dict[str, Any]:
+    """
+    ...
+
+    Raises:
+        FileNotFoundError: ファイルが存在しない場合
+        PermissionError: ファイルの読み取り権限がない場合
+        ValueError: JSON形式が無効な場合
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise FileNotFoundError(f"設定ファイルが見つかりません: {file_path}")
+    except PermissionError:
+        raise PermissionError(f"設定ファイルの読み取り権限がありません: {file_path}")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"無効なJSON形式: {file_path}") from e
+
+# Bad: 汎用的な例外キャッチ
+def read_config_file(file_path: str) -> dict[str, Any]:
+    try:
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    except Exception as e:  # 何でもキャッチしてしまう
+        print(f"Error: {e}")
+        return {}
+```
+
+#### カスタム例外の定義と使用
+
+```python
+# ドメイン固有の例外クラスを定義
+class UserNotFoundError(ValueError):
+    """ユーザーが見つからない場合の例外。"""
+
+    def __init__(self, user_id: int) -> None:
+        super().__init__(f"ユーザーが見つかりません: {user_id}")
+        self.user_id = user_id
+
+class InvalidUserDataError(ValueError):
+    """無効なユーザーデータの場合の例外。"""
+    pass
+
+# 使用例
+def get_user(user_id: int) -> User:
+    """
+    ...
+
+    Raises:
+        UserNotFoundError: 指定されたユーザーが存在しない場合
+    """
+    user = repository.find_by_id(user_id)
+    if user is None:
+        raise UserNotFoundError(user_id)
+    return user
+```
+
+## 命名規則
+
+### 基本原則
+
+- 関数名は、変数、モジュールは`snake_case`を使用
+- クラス名、型、列挙型は`CamelCase`を使用
+- 定数と静的変数には`SCREAMING_SNAKE_CASE`を使用
+- 意味のある名前を使用し、短縮形や略語は避ける
+  - 例: `uid` や `db_conn` ではなく、`user_id` や `database_connection` を使用
+
+## コメントとドキュメント
+
+### コメント
+
+- WHY を説明し、WHAT は避けます。コードから明らかな内容ではなく、なぜその実装を選択したのか、どのような背景や制約があるのかを説明します。
+- コメントはコードの意図を明確にするために使用し、冗長なコメントや明白な内容は避ける
+
+### Docstring
+
+- Google style のドキュメンテーション文字列（docstring）を使用
+- 記載内容:
+  - 関数/クラスの機能を簡潔に説明
+  - Args: 引数の説明
+  - Returns: 戻り値の説明
+  - どのような例外が発生するかを記載
+
+```python
+def fetch_user_name(user_id: int) -> str:
+    """
+    ユーザーIDからユーザー名を取得する。
+
+    Args:
+        user_id (int): ユーザーのID
+
+    Returns:
+        str: ユーザー名
+
+    Raises:
+        UserNotFoundError: 指定されたユーザーが存在しない場合
+    """
+    ...
+```
+
+## 制御フロー
+
+### ガード節
+
+ガード節は、異常系や特別なケースを関数の冒頭で処理し、else 句を使わずに早期リターンする書き方です。
+
+```python
+# Bad: 深いネスト
+def process_order(order):
+    if order is not None:
+        if order.is_valid():
+            if order.has_items():
+                return calculate_total(order)
+            else:
+                return 0
+        else:
+            raise InvalidOrderError()
+    else:
+        raise OrderNotFoundError()
+
+# Good: ガード節で早期リターン
+def process_order(order):
+    if order is None:
+        raise OrderNotFoundError()
+
+    if not order.is_valid():
+        raise InvalidOrderError()
+
+    if not order.has_items():
+        return 0
+
+    return calculate_total(order)
+```
+
+## 関数設計
+
+### 単一責任の原則
+
+1 つの関数は 1 つのことだけを行うべきです。ユーザーデータ処理関数がバリデーション、データ変換、データベース保存、メール送信を全て行うのではなく、それぞれを独立した関数に分離します。これにより各機能のテストが容易になり、変更時の影響範囲が限定されます。
+
+### 関数の長さ制限
+
+1 関数は 20-30 行以内を目安とします。これを超える場合は、論理的なまとまりで複数の関数に分割します。長い関数は理解が困難で、テストやデバッグが困難になります。
+
+### 引数の数制限
+
+引数は 3-4 個以内を推奨します。多い場合は pydantic モデルや dataclass を活用して関連するパラメータをまとめることを検討します。
+
+### 純粋関数の推奨
+
+副作用のない関数を可能な限り作成します。同じ入力に対して常に同じ出力を返し、外部状態を変更しない関数は、テストが容易で予測可能な動作をします。
+
+## クラス設計（Python）
+
+### いつクラスを使うか
+
+- 値オブジェクト: 同じ属性なら同一と見なせる（例: Point(x, y), RGB(r, g, b)）。入力バリデーションが不要なら `@dataclass(frozen=True)`、バリデーションが必要なら `pydantic.BaseModel (v2) + frozen=True` を推奨。
+
+- エンティティ: 一意な ID とライフサイクルを持つ（例: `User(id, name, email)`）。
+- サービスオブジェクト: 状態をほぼ持たず、振る舞いをまとめる。@staticmethod か関数で十分ならクラスを避ける。
+
+### クラス構成の原則
+
+| 観点                  | 推奨                                                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| **単一責任**          | 1 クラス = 1 概念。副作用のあるユーティリティ関数を混在させない。                        |
+| **公開 API の最小化** | `__all__` または `_private` 命名で外部インターフェースを明示。                           |
+| **継承より構成**      | まず委譲 (`has-a`) を検討し、どうしても共通ロジックを再利用したい場合のみ継承 (`is-a`)。 |
+| **データ表現**        | 不変データは `@dataclass(frozen=True)`, `typing.NamedTuple`, `attrs` などで簡潔に。      |
+| **リソース管理**      | 外部リソースを握る場合は `__enter__ / __exit__` を実装し `with` で使えるように。         |
+| **型ヒント**          | すべての属性・引数・戻り値を `typing` で明示し、mypy を CI に統合。                      |
+| **immutability**      | 意図しない再代入を防ぐため、可能なら `frozen=True` や `__slots__` を利用。               |

--- a/config/claude_code/python/uv.md
+++ b/config/claude_code/python/uv.md
@@ -1,0 +1,374 @@
+# uv のまとめ
+
+## 概要
+
+uv は以下のような特徴を持つ python パッケージおよびプロジェクト管理ツールです
+
+- pip、pip-tools、pipx、poetry、pyenv、twine、virtualenv などを置き換える単一のツール
+- pip よりも 10〜100 倍高速
+- ユニバーサルロックファイルを含む包括的なプロジェクト管理機能
+- インライン依存関係メタデータをサポートしたスクリプト実行機能
+- 依存関係の重複排除のためのグローバルキャッシュによる効率的なディスク使用
+
+## インストール
+
+### （推奨）mise からインストールする方法
+
+```bash
+mise install uv
+```
+
+### スタンドアローンインストーラーを使用する方法
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+## 使い方
+
+### プロジェクト管理
+
+#### プロジェクト初期化
+
+新しいプロジェクトを作成します。`pyproject.toml`ファイルが生成され、プロジェクトのメタデータや依存関係が含まれます。
+
+```bash
+# 現在のディレクトリにプロジェクトを初期化
+uv init
+
+# 指定したディレクトリにプロジェクトを作成
+uv init my_project
+
+# ライブラリプロジェクトとして初期化（配布用パッケージ）
+uv init --lib my_library
+
+# アプリケーションプロジェクトとして初期化（CLI/Webアプリなど）
+uv init --app my_app
+
+# スクリプトファイルを作成（PEP 723対応）
+uv init --script script.py
+```
+
+#### 依存関係の追加・削除
+
+プロジェクトに依存関係を追加または削除します。
+
+```bash
+# パッケージを追加
+uv add requests
+
+# 特定のバージョンを指定して追加
+uv add "django>=4.0,<5.0"
+
+# 開発依存関係として追加
+uv add --dev pytest
+
+# オプショナル依存関係として追加
+uv add --optional test pytest coverage
+
+# 依存関係グループに追加
+uv add --group lint ruff mypy
+
+# パッケージを削除
+uv remove requests
+
+# 開発依存関係を削除
+uv remove --dev pytest
+```
+
+#### 仮想環境の管理
+
+プロジェクトの仮想環境を作成・管理します。
+
+```bash
+# 仮想環境を作成（.venvディレクトリに作成される）
+uv venv
+
+# 特定のPythonバージョンで仮想環境を作成
+uv venv --python 3.11
+
+# 指定したパスに仮想環境を作成
+uv venv /path/to/venv
+
+# システムサイトパッケージにアクセス可能な仮想環境を作成
+uv venv --system-site-packages
+
+# seed パッケージ（pip、setuptools、wheel）をインストール
+uv venv --seed
+```
+
+#### プロジェクト環境の同期
+
+プロジェクトの依存関係をインストールし、環境を最新状態にします。
+
+```bash
+# プロジェクト環境を同期（依存関係をインストール）
+uv sync
+
+# 開発依存関係も含めて同期
+uv sync --dev
+
+# 特定のオプショナル依存関係を含めて同期
+uv sync --extra test
+
+# すべてのオプショナル依存関係を含めて同期
+uv sync --all-extras
+
+# 特定の依存関係グループを含めて同期
+uv sync --group lint
+
+# 厳密でない同期（余分なパッケージを削除しない）
+uv sync --inexact
+
+# プロジェクト自体をインストールしない
+uv sync --no-install-project
+```
+
+#### ロックファイルの管理
+
+プロジェクトの依存関係を解決し、ロックファイルを生成・更新します。
+
+```bash
+# ロックファイル（uv.lock）を生成・更新
+uv lock
+
+# ロックファイルが最新かチェック
+uv lock --check
+
+# ドライランモード（実際に書き込まない）
+uv lock --dry-run
+
+# パッケージをアップグレードしてロック
+uv lock --upgrade
+
+# 特定のパッケージのみアップグレード
+uv lock --upgrade-package requests
+```
+
+### スクリプト実行とコマンド実行
+
+#### プロジェクト内でのコマンド実行
+
+プロジェクト環境でコマンドやスクリプトを実行します。
+
+```bash
+# Pythonスクリプトを実行
+uv run python script.py
+
+# モジュールを実行
+uv run -m pytest
+
+# 一時的に依存関係を追加して実行
+uv run --with requests python script.py
+
+# requirements.txtの依存関係を追加して実行
+uv run --with-requirements requirements.txt python script.py
+
+# 分離された環境で実行
+uv run --isolated python script.py
+
+# PEP 723スクリプトを実行
+uv run script.py
+
+# 環境変数ファイルを読み込んで実行
+uv run --env-file .env python script.py
+```
+
+### パッケージ管理（pip 互換インターフェース）
+
+> **⚠️ 重要な注意事項**
+>
+> `uv pip` コマンドは既存の pip と互換性のためのインターフェースです。**通常のプロジェクト開発では `uv add`、`uv remove`、`uv sync` を使用することを強く推奨します。**
+>
+> `uv pip` を使用するのは以下の場合のみにしてください：
+>
+> - ライブラリのドキュメントで明示的に `pip install` が推奨されている場合
+> - レガシーシステムとの互換性が必要な場合
+> - プロジェクト管理外で一時的にパッケージをテストする場合
+
+#### パッケージのインストール・アンインストール
+
+```bash
+# パッケージをインストール（非推奨 - 代わりに uv add を使用）
+uv pip install requests
+
+# requirements.txtからインストール（非推奨 - 代わりに uv sync を使用）
+uv pip install -r requirements.txt
+
+# パッケージをアンインストール（非推奨 - 代わりに uv remove を使用）
+uv pip uninstall requests
+
+# インストール済みパッケージの一覧表示
+uv pip list
+
+# パッケージの詳細情報表示
+uv pip show requests
+
+# 依存関係ツリーの表示
+uv tree
+```
+
+### Python バージョン管理
+
+#### Python インタープリターの管理
+
+```bash
+# 利用可能なPythonバージョンを表示
+uv python list
+
+# 特定のPythonバージョンをインストール
+uv python install 3.11
+
+# インストール済みのPythonバージョンを表示
+uv python list --only-installed
+
+# Pythonインタープリターの場所を表示
+uv python find
+
+# 特定のバージョンのPythonインタープリターを検索
+uv python find 3.11
+```
+
+### ワークスペース管理
+
+#### マルチパッケージプロジェクト
+
+```bash
+# ワークスペース全体を同期
+uv sync --all-packages
+
+# 特定のワークスペースメンバーのみ同期
+uv sync --package my-package
+
+# ワークスペース全体で依存関係を追加
+uv add --package my-package requests
+```
+
+### キャッシュ管理
+
+#### キャッシュの表示・削除
+
+```bash
+# キャッシュディレクトリの場所を表示
+uv cache dir
+
+# キャッシュサイズを表示
+uv cache size
+
+# キャッシュをクリア
+uv cache clean
+
+# 特定のパッケージのキャッシュをクリア
+uv cache clean requests
+```
+
+### 設定とオプション
+
+#### グローバルオプション
+
+```bash
+# 詳細出力でコマンドを実行
+uv --verbose sync
+
+# 静寂モードでコマンドを実行
+uv --quiet sync
+
+# オフラインモードで実行（ネットワークアクセスなし）
+uv --offline sync
+
+# キャッシュを使用しない
+uv --no-cache sync
+
+# 特定のディレクトリで実行
+uv --directory /path/to/project sync
+
+# 設定ファイルを指定
+uv --config-file uv.toml sync
+```
+
+#### 環境変数での設定
+
+主要な環境変数：
+
+```bash
+# デフォルトのPythonインタープリター
+export UV_PYTHON=3.11
+
+# キャッシュディレクトリ
+export UV_CACHE_DIR=/path/to/cache
+
+# プロジェクトディレクトリ
+export UV_PROJECT=/path/to/project
+
+# インデックスURL
+export UV_INDEX_URL=https://pypi.org/simple
+
+# ネットワークアクセス無効化
+export UV_OFFLINE=1
+
+# キャッシュ無効化
+export UV_NO_CACHE=1
+```
+
+### よく使用されるワークフロー
+
+#### 新しいプロジェクトの開始
+
+```bash
+# プロジェクトを作成
+uv init my-project
+cd my-project
+
+# 依存関係を追加
+uv add requests pytest
+
+# 環境を同期
+uv sync
+
+# テストを実行
+uv run pytest
+```
+
+#### 既存プロジェクトのセットアップ
+
+```bash
+# プロジェクトディレクトリに移動
+cd existing-project
+
+# 環境を同期（依存関係をインストール）
+uv sync
+
+# アプリケーションを実行
+uv run python main.py
+```
+
+#### 依存関係の更新
+
+```bash
+# 全ての依存関係を最新バージョンに更新
+uv lock --upgrade
+uv sync
+
+# 特定のパッケージのみ更新
+uv lock --upgrade-package requests
+uv sync
+```
+
+#### 開発環境での作業
+
+```bash
+# 開発依存関係を含めて環境をセットアップ
+uv sync --dev
+
+# リンターを実行
+uv run ruff check
+
+# フォーマッターを実行
+uv run ruff format
+
+# テストを実行
+uv run pytest
+
+# 型チェックを実行
+uv run mypy src/
+```

--- a/config/mise/mise.toml
+++ b/config/mise/mise.toml
@@ -25,3 +25,6 @@ tflint = "latest"
 packer = "latest"
 gcloud = "latest"
 tilt = "0.34.0"
+
+[settings]
+idiomatic_version_file_enable_tools = ["python"]

--- a/config/vscode/settings.json
+++ b/config/vscode/settings.json
@@ -24,7 +24,6 @@
     "*": true,
     "markdown": true
   },
-  "chat.experimental.detectParticipant.enabled": true,
   "html.format.wrapLineLength": 150,
   "remote.SSH.useLocalServer": false,
   "security.workspace.trust.untrustedFiles": "open",


### PR DESCRIPTION
## Summary
- Claude Code用のPython開発スタイルガイドを追加
- uvパッケージマネージャーのドキュメントを追加  
- mise設定でPythonバージョンファイル自動認識を有効化

## Changes
- `config/claude_code/python/python_coding_style.md`: Python開発におけるコーディングスタイル、型安全性、エラーハンドリング、テスト戦略の詳細ガイドを追加
- `config/claude_code/python/uv.md`: uvパッケージマネージャーの包括的な使用方法ドキュメントを追加
- `config/mise/mise.toml`: `idiomatic_version_file_enable_tools`設定でPythonバージョンファイル(.python-version等)の自動認識を有効化
- `config/vscode/settings.json`: 非推奨のchat実験的機能設定を削除

## Additional notes
- Python 3.12以上を前提とした最新のベストプラクティスに対応
- ruff、mypy、pytestを使用した開発フローを標準化
- pipの使用を禁止し、uvへの完全移行を推進

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>