### PR TITLE
🔧 chore: Git設定からGitHub認証情報とGPG署名設定を削除

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -37,15 +37,3 @@
 
 [rebase]
     updateRefs = true
-
-[url "git@github.com:"]
-    pushInsteadOf = https://github.com/
-[credential "https://github.com"]
-	helper = 
-	helper = !/usr/bin/gh auth git-credential
-[credential "https://gist.github.com"]
-	helper = 
-	helper = !/usr/bin/gh auth git-credential
-[commit]
-	gpgsign = false
-	


### PR DESCRIPTION
## Summary
- Git設定ファイルからGitHub認証情報の設定を削除
- GPG署名設定を削除
- 設定ファイルの末尾の空行を削除

## Test plan
- [x] 設定ファイルの変更が適切に反映されていることを確認
- [x] Git操作が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)