### PR TITLE
🔧 chore: GitHubへのHTTPSリダイレクトとGH認証ヘルパーを追加

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -37,3 +37,13 @@
 
 [rebase]
     updateRefs = true
+
+[url "https://github.com/"]
+    insteadOf = git@github.com:
+    insteadOf = ssh://git@github.com/
+
+[credential "https://github.com"]
+	helper = "!gh auth git-credential"
+
+[credential "https://gist.github.com"]
+	helper = "!gh auth git-credential"


### PR DESCRIPTION
## Summary
- GitHub SSH接続をHTTPS接続にリダイレクトする設定を追加
- GitHub CLI認証ヘルパーをGitHub/Gist用に設定
- Git設定の強化によりHTTPS接続時の認証をスムーズに実行

## Changes
- `config/git/config`にHTTPSリダイレクト設定を追加
- GitHub CLI認証ヘルパーの設定を追加
- SSH接続をHTTPS接続に自動変換する設定を実装

## Test plan
- [ ] Git設定が正しく適用されることを確認
- [ ] GitHub/Gistへの接続が正常に動作することを確認
- [ ] HTTPS認証が期待通りに機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)