### PR TITLE
🔧 chore: dotfiles設定の整理と改善

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
       - id: no-commit-to-branch
         args: ["--branch", "main"]

--- a/config/vscode/settings.json
+++ b/config/vscode/settings.json
@@ -96,5 +96,6 @@
   "liveServer.settings.donotShowInfoMsg": true,
   "githubPullRequests.terminalLinksHandler": "github",
   "remote.extensionKind": {"Anthropic.claude-code": ["ui", "workspace"]},
-  "diffEditor.renderSideBySide": true
+  "diffEditor.renderSideBySide": true,
+  "biome.suggestInstallingGlobally": false
 }

--- a/config/zsh/.zshenv
+++ b/config/zsh/.zshenv
@@ -2,6 +2,7 @@ export LANG="en_US.UTF-8"
 unsetopt GLOBAL_RCS
 
 export PATH="$HOME/.local/bin:$PATH"
+export PATH="/usr/local/bin:$PATH"
 
 # docker
 export PATH="$HOME/.docker/bin:$PATH"

--- a/install/common/sheldon.sh
+++ b/install/common/sheldon.sh
@@ -4,7 +4,7 @@ set -Eeuxo pipefail
 
 function install_sheldon() {
     curl --proto '=https' -fLsS https://rossmacarthur.github.io/install/crate.sh \
-        | bash -s -- --repo rossmacarthur/sheldon --to ~/.local/bin
+        | bash -s -- --repo rossmacarthur/sheldon --to ~/.local/bin --force
 }
 
 function uninstall_sheldon() {
@@ -18,8 +18,3 @@ function main() {
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     main
 fi
-
-
-
-
-

--- a/install/link.sh
+++ b/install/link.sh
@@ -78,5 +78,4 @@ if [ ! -d "$CLAUDE_CODE_DIR" ]; then
     mkdir -p "$CLAUDE_CODE_DIR"
 fi
 ln -sf "$REPO_DIR"/config/claude_code/CLAUDE.md "$CLAUDE_CODE_DIR"/CLAUDE.md
-ln -sf "$REPO_DIR"/config/claude_code/settings.json "$CLAUDE_CODE_DIR"/settings.json
 ln -sf "$REPO_DIR"/config/claude_code/commands "$CLAUDE_CODE_DIR"


### PR DESCRIPTION
## Summary
- Claude Code設定ファイルから不要なリンクを削除
- sheldonインストールスクリプトの安定性向上
- zsh環境設定の最適化
- VSCode設定の改善
- pre-commitフックの追加

## Changes
- `install/link.sh`: Claude Code設定ファイルのリンクからsettings.jsonを削除
- `install/common/sheldon.sh`: --forceオプションを追加してインストールの安定性を向上
- `config/zsh/.zshenv`: /usr/local/binパスを追加してシステムツールへのアクセスを改善
- `config/vscode/settings.json`: Biomeのグローバルインストール提案を無効化
- `.pre-commit-config.yaml`: trailing-whitespaceとend-of-file-fixerフックを追加

## Test plan
- [ ] macOS環境でのdotfilesセットアップテスト
- [ ] zsh環境でのパス設定確認
- [ ] sheldonインストールの動作確認
- [ ] pre-commitフックの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)