### PR TITLE
chore: update mise config and zshrc fpath OS detection

### DIFF
--- a/config/mise/mise.toml
+++ b/config/mise/mise.toml
@@ -25,7 +25,6 @@ packer = "latest"
 gcloud = "latest"
 tilt = "latest"
 "npm:@anthropic-ai/claude-code" = "latest"
-gemini-cli = "latest"
 ghq = "latest"
 copier = "latest"
 fzf ="latest"
@@ -43,6 +42,7 @@ helix = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python"]
+install_before = "7d"
 
 [settings.npm]
 bun = true

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -1,7 +1,11 @@
 HISTFILE="${ZDOTDIR:-$HOME}/.zsh_history"
 
-fpath+=("$(brew --prefix)/share/zsh/site-functions")
-autoload -U promptinit; promptinit
+if [[ "$OSTYPE" == darwin* ]]; then
+    fpath+=("$(brew --prefix)/share/zsh/site-functions")
+else
+    fpath=(~/.zsh/pure $fpath)
+fi
+autoload -Uz promptinit; promptinit
 prompt pure
 
 alias cat='bat'


### PR DESCRIPTION
## Summary
- miseからgemini-cliを削除
- miseに`install_before`設定を追加
- zshrcのfpathをOS別に切り替え（macOS: Homebrew、Ubuntu: ~/.zsh/pure）