### PR TITLE
chore: tune claude code and codex settings

### DIFF
--- a/config/claude_code/settings.json
+++ b/config/claude_code/settings.json
@@ -2,7 +2,7 @@
   "env": {
     "DISABLE_AUTOUPDATER": "1",
     "DISABLE_BUG_COMMAND": "true",
-    "effort": "medium"
+    "effort": "xhigh"
   },
   "includeCoAuthoredBy": false,
   "permissions": {
@@ -32,10 +32,12 @@
       "NotebookRead"
     ],
     "additionalDirectories": [
-      "~/Google Drive/マイドライブ/Obsidian Vault/"
+      "~/Google Drive/マイドライブ/Obsidian Vault/",
+      "~/.claude/"
     ],
-    "defaultMode": "plan"
+    "defaultMode": "auto"
   },
+  "model": "opus",
   "hooks": {
     "PostToolUse": [
       {
@@ -77,15 +79,14 @@
       }
     ]
   },
-  "showClearContextOnPlanAccept": true,
-  "model": "opusplan",
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.py"
   },
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true,
-    "dig@kuu-marketplace": true
+    "frontend-design@claude-plugins-official": true
   },
-  "alwaysThinkingEnabled": true
+  "alwaysThinkingEnabled": true,
+  "showClearContextOnPlanAccept": true,
+  "skipAutoPermissionPrompt": true
 }

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,5 +1,5 @@
-model = "gpt-5.4"
-model_reasoning_effort = "medium"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 hide_agent_reasoning = true
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"


### PR DESCRIPTION
## Summary
- Claude Code を auto モード + opus モデルに切り替え、reasoning effort を xhigh に引き上げる
- Codex を gpt-5.5 / high reasoning effort にアップデートする

## Changes
- `config/claude_code/settings.json`
  - `effort` を `medium` → `xhigh`
  - `additionalDirectories` に `~/.claude/` を追加
  - `defaultMode` を `plan` → `auto`、`model` を `opusplan` → `opus`
  - `dig@kuu-marketplace` プラグインを削除
  - `skipAutoPermissionPrompt: true` を追加
- `config/codex/config.toml`
  - `model` を `gpt-5.4` → `gpt-5.5`
  - `model_reasoning_effort` を `medium` → `high`
  - 末尾改行を追加

## Test plan
- 設定ファイルの構文整合は diff レビューで確認 (実環境での挙動確認は未実施)