### PR TITLE
chore: install agent skills via npx skills

### DIFF
--- a/config/claude_code/skills/fireworks-tech-graph
+++ b/config/claude_code/skills/fireworks-tech-graph
@@ -1,1 +1,0 @@
-../../.agents/skills/fireworks-tech-graph

--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuxo pipefail
+
+function install_skills() {
+    zsh -c '
+        source ~/.zshenv
+        source ~/.zshrc
+        npx -y skills@latest add yizhiyanhua-ai/fireworks-tech-graph -g -y -a claude-code -a codex
+        npx -y skills@latest add mattpocock/skills --skill grill-me -g -y -a claude-code -a codex
+    '
+}
+
+function main() {
+    install_skills
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/link.sh
+++ b/install/link.sh
@@ -81,8 +81,13 @@ ln -sf "$REPO_DIR"/config/claude_code/statusline.py "$CLAUDE_CODE_DIR/statusline
 ln -sf "$REPO_DIR"/config/claude_code/agents "$CLAUDE_CODE_DIR"
 ln -sf "$REPO_DIR"/config/claude_code/commands "$CLAUDE_CODE_DIR"
 ln -sf "$REPO_DIR"/config/claude_code/rules "$CLAUDE_CODE_DIR"
-ln -sf "$REPO_DIR"/config/claude_code/skills "$CLAUDE_CODE_DIR"
 ln -sf "$REPO_DIR"/config/claude_code/hooks "$CLAUDE_CODE_DIR"
+
+mkdir -p "$CLAUDE_CODE_DIR/skills"
+for skill in "$REPO_DIR"/config/claude_code/skills/*; do
+    [ -e "$skill" ] || continue
+    ln -sfn "$skill" "$CLAUDE_CODE_DIR/skills/$(basename "$skill")"
+done
 chmod +x "$CLAUDE_CODE_DIR"/statusline.py
 chmod +x "$CLAUDE_CODE_DIR"/hooks/cmux-notify.sh
 

--- a/install/mac/setup.sh
+++ b/install/mac/setup.sh
@@ -33,5 +33,11 @@ echo "Executing ${VSCODE_SCRIPT}..."
 chmod +x "${VSCODE_SCRIPT}"
 bash "${VSCODE_SCRIPT}"
 
+# install agent skills
+readonly SKILLS_SCRIPT="${ROOT_DIR}"/common/skills.sh
+echo "Executing ${SKILLS_SCRIPT}..."
+chmod +x "${SKILLS_SCRIPT}"
+bash "${SKILLS_SCRIPT}"
+
 # install battery
 curl -s https://raw.githubusercontent.com/actuallymentor/battery/main/setup.sh | bash

--- a/install/ubuntu/setup.sh
+++ b/install/ubuntu/setup.sh
@@ -33,5 +33,11 @@ echo "Executing ${VSCODE_SCRIPT}..."
 chmod +x "${VSCODE_SCRIPT}"
 bash "${VSCODE_SCRIPT}"
 
+# install agent skills
+readonly SKILLS_SCRIPT="${ROOT_DIR}"/common/skills.sh
+echo "Executing ${SKILLS_SCRIPT}..."
+chmod +x "${SKILLS_SCRIPT}"
+bash "${SKILLS_SCRIPT}"
+
 # install battery
 curl -s https://raw.githubusercontent.com/actuallymentor/battery/main/setup.sh | bash


### PR DESCRIPTION
## Summary
- mac/ubuntu セットアップで `npx skills@latest add` を実行し fireworks-tech-graph と grill-me をグローバル導入
- `~/.claude/skills` を per-entry symlink 構造に変更し、skills CLI が作る相対 symlink を解決可能にする

## Changes
- `install/common/skills.sh`: `yizhiyanhua-ai/fireworks-tech-graph` と `mattpocock/skills` の `grill-me` を claude-code / codex 向けに `npx skills@latest add -g -y` でインストール
- `install/{mac,ubuntu}/setup.sh`: mise の直後・battery の前で `skills.sh` を呼び出すブロックを追加
- `install/link.sh`: `~/.claude/skills` を一括 symlink から「実ディレクトリ + 配下を per-entry symlink」に変更
- `config/claude_code/skills/fireworks-tech-graph`: 旧構造で壊れていた committed symlink を削除

## Test plan
- `shellcheck install/common/skills.sh install/{mac,ubuntu}/setup.sh install/link.sh` で警告ゼロを確認済み
- 旧 link.sh + skills.sh の挙動で `~/.claude/skills/{fireworks-tech-graph,grill-me}` が壊れた symlink になり `/skill` 一覧から漏れることを再現確認済み
- 修正後の `bash install/link.sh && bash install/common/skills.sh` の再走確認は未実施（マージ前にローカルで実走し、`/skill` 一覧に表示されることを確認予定）

## Additional notes
- vercel-labs/skills CLI は symlink target を相対パスで書き出すため、`~/.claude/skills` 自体が symlink だと解決元が `<repo>/config/claude_code/skills/` になり `../../.agents/skills/...` が `<repo>/config/.agents/...` を指して壊れる。`~/.claude/skills` を実ディレクトリ化することでこの問題を解消する。