### PR TITLE
chore: register o'reilly mcp server in codex config

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -24,3 +24,9 @@ sandbox_mode = "read-only"
 [features]
 goals = true
 terminal_resize_reflow = true
+
+[mcp_servers.oreilly]
+url = "https://api.oreilly.com/api/content-discovery/v1/mcp/"
+
+[mcp_servers.oreilly.tools.search_oreilly_content]
+approval_mode = "approve"


### PR DESCRIPTION
## Summary
- codex の MCP サーバ設定に O'Reilly の content discovery エンドポイントを追加する。
- `search_oreilly_content` ツールには明示承認を必須化する。

## Changes
- `config/codex/config.toml` の末尾に `[mcp_servers.oreilly]` セクションを追加し `url` を設定。
- `[mcp_servers.oreilly.tools.search_oreilly_content]` で `approval_mode = "approve"` を指定し、ツール実行前にユーザ承認が走るようにする。

## Test plan
- `git diff` で対象が `config/codex/config.toml` のみであることを確認した。
- 実際の MCP サーバ接続テストはこの PR では行っていない。codex 起動時に挙動確認する。

## Additional notes
- paper-explainer skill 追加は別 PR (#69) に分離している。